### PR TITLE
fix: prevent votes on group proposals if current user isn't a group member

### DIFF
--- a/schema.graphql
+++ b/schema.graphql
@@ -98,6 +98,7 @@ type Group {
   description: String!
   feed: [FeedItem!]!
   id: Int!
+  isJoinedByMe: Boolean!
   memberCount: Int!
   memberRequestCount: Int!
   members: [GroupMember!]!

--- a/src/apollo/gen.ts
+++ b/src/apollo/gen.ts
@@ -976,8 +976,8 @@ export type GroupProfileQuery = {
           };
           group?: {
             __typename?: "Group";
-            isJoinedByMe: boolean;
             id: number;
+            isJoinedByMe: boolean;
             name: string;
             coverPhoto?: { __typename?: "Image"; id: number } | null;
           } | null;
@@ -1213,8 +1213,8 @@ type FeedItem_Proposal_Fragment = {
   };
   group?: {
     __typename?: "Group";
-    isJoinedByMe: boolean;
     id: number;
+    isJoinedByMe: boolean;
     name: string;
     coverPhoto?: { __typename?: "Image"; id: number } | null;
   } | null;
@@ -1436,8 +1436,8 @@ export type ProposalCardFragment = {
   };
   group?: {
     __typename?: "Group";
-    isJoinedByMe: boolean;
     id: number;
+    isJoinedByMe: boolean;
     name: string;
     coverPhoto?: { __typename?: "Image"; id: number } | null;
   } | null;
@@ -1471,6 +1471,7 @@ export type ProposalCardFooterFragment = {
       profilePicture: { __typename?: "Image"; id: number };
     };
   }>;
+  group?: { __typename?: "Group"; id: number; isJoinedByMe: boolean } | null;
 };
 
 export type ProposalFormFragment = {
@@ -1527,8 +1528,8 @@ export type CreateProposalMutation = {
       };
       group?: {
         __typename?: "Group";
-        isJoinedByMe: boolean;
         id: number;
+        isJoinedByMe: boolean;
         name: string;
         coverPhoto?: { __typename?: "Image"; id: number } | null;
       } | null;
@@ -1592,8 +1593,8 @@ export type UpdateProposalMutation = {
       };
       group?: {
         __typename?: "Group";
-        isJoinedByMe: boolean;
         id: number;
+        isJoinedByMe: boolean;
         name: string;
         coverPhoto?: { __typename?: "Image"; id: number } | null;
       } | null;
@@ -1672,8 +1673,8 @@ export type ProposalQuery = {
     };
     group?: {
       __typename?: "Group";
-      isJoinedByMe: boolean;
       id: number;
+      isJoinedByMe: boolean;
       name: string;
       coverPhoto?: { __typename?: "Image"; id: number } | null;
     } | null;
@@ -2016,8 +2017,8 @@ export type FollowUserMutation = {
             };
             group?: {
               __typename?: "Group";
-              isJoinedByMe: boolean;
               id: number;
+              isJoinedByMe: boolean;
               name: string;
               coverPhoto?: { __typename?: "Image"; id: number } | null;
             } | null;
@@ -2219,8 +2220,8 @@ export type HomePageQuery = {
           };
           group?: {
             __typename?: "Group";
-            isJoinedByMe: boolean;
             id: number;
+            isJoinedByMe: boolean;
             name: string;
             coverPhoto?: { __typename?: "Image"; id: number } | null;
           } | null;
@@ -2324,8 +2325,8 @@ export type UserProfileQuery = {
           };
           group?: {
             __typename?: "Group";
-            isJoinedByMe: boolean;
             id: number;
+            isJoinedByMe: boolean;
             name: string;
             coverPhoto?: { __typename?: "Image"; id: number } | null;
           } | null;
@@ -2667,6 +2668,10 @@ export const ProposalCardFooterFragmentDoc = gql`
         id
       }
     }
+    group {
+      id
+      isJoinedByMe
+    }
     ...VoteMenu
     ...VoteBadges
   }
@@ -2692,7 +2697,6 @@ export const ProposalCardFragmentDoc = gql`
       ...UserAvatar
     }
     group {
-      isJoinedByMe
       ...GroupAvatar
     }
     images {

--- a/src/apollo/gen.ts
+++ b/src/apollo/gen.ts
@@ -134,6 +134,7 @@ export type Group = {
   description: Scalars["String"];
   feed: Array<FeedItem>;
   id: Scalars["Int"];
+  isJoinedByMe: Scalars["Boolean"];
   memberCount: Scalars["Int"];
   memberRequestCount: Scalars["Int"];
   members: Array<GroupMember>;
@@ -975,6 +976,7 @@ export type GroupProfileQuery = {
           };
           group?: {
             __typename?: "Group";
+            isJoinedByMe: boolean;
             id: number;
             name: string;
             coverPhoto?: { __typename?: "Image"; id: number } | null;
@@ -1211,6 +1213,7 @@ type FeedItem_Proposal_Fragment = {
   };
   group?: {
     __typename?: "Group";
+    isJoinedByMe: boolean;
     id: number;
     name: string;
     coverPhoto?: { __typename?: "Image"; id: number } | null;
@@ -1433,6 +1436,7 @@ export type ProposalCardFragment = {
   };
   group?: {
     __typename?: "Group";
+    isJoinedByMe: boolean;
     id: number;
     name: string;
     coverPhoto?: { __typename?: "Image"; id: number } | null;
@@ -1523,6 +1527,7 @@ export type CreateProposalMutation = {
       };
       group?: {
         __typename?: "Group";
+        isJoinedByMe: boolean;
         id: number;
         name: string;
         coverPhoto?: { __typename?: "Image"; id: number } | null;
@@ -1587,6 +1592,7 @@ export type UpdateProposalMutation = {
       };
       group?: {
         __typename?: "Group";
+        isJoinedByMe: boolean;
         id: number;
         name: string;
         coverPhoto?: { __typename?: "Image"; id: number } | null;
@@ -1666,6 +1672,7 @@ export type ProposalQuery = {
     };
     group?: {
       __typename?: "Group";
+      isJoinedByMe: boolean;
       id: number;
       name: string;
       coverPhoto?: { __typename?: "Image"; id: number } | null;
@@ -2009,6 +2016,7 @@ export type FollowUserMutation = {
             };
             group?: {
               __typename?: "Group";
+              isJoinedByMe: boolean;
               id: number;
               name: string;
               coverPhoto?: { __typename?: "Image"; id: number } | null;
@@ -2211,6 +2219,7 @@ export type HomePageQuery = {
           };
           group?: {
             __typename?: "Group";
+            isJoinedByMe: boolean;
             id: number;
             name: string;
             coverPhoto?: { __typename?: "Image"; id: number } | null;
@@ -2315,6 +2324,7 @@ export type UserProfileQuery = {
           };
           group?: {
             __typename?: "Group";
+            isJoinedByMe: boolean;
             id: number;
             name: string;
             coverPhoto?: { __typename?: "Image"; id: number } | null;
@@ -2682,6 +2692,7 @@ export const ProposalCardFragmentDoc = gql`
       ...UserAvatar
     }
     group {
+      isJoinedByMe
       ...GroupAvatar
     }
     images {

--- a/src/apollo/proposals/fragments/ProposalCard.fragment.graphql
+++ b/src/apollo/proposals/fragments/ProposalCard.fragment.graphql
@@ -20,6 +20,7 @@ fragment ProposalCard on Proposal {
   }
 
   group {
+    isJoinedByMe
     ...GroupAvatar
   }
 

--- a/src/apollo/proposals/fragments/ProposalCard.fragment.graphql
+++ b/src/apollo/proposals/fragments/ProposalCard.fragment.graphql
@@ -20,7 +20,6 @@ fragment ProposalCard on Proposal {
   }
 
   group {
-    isJoinedByMe
     ...GroupAvatar
   }
 

--- a/src/apollo/proposals/fragments/ProposalCardFooter.fragment.graphql
+++ b/src/apollo/proposals/fragments/ProposalCardFooter.fragment.graphql
@@ -8,6 +8,11 @@ fragment ProposalCardFooter on Proposal {
     }
   }
 
+  group {
+    id
+    isJoinedByMe
+  }
+
   ...VoteMenu
   ...VoteBadges
 }

--- a/src/components/Proposals/ProposalCard.tsx
+++ b/src/components/Proposals/ProposalCard.tsx
@@ -58,7 +58,6 @@ interface Props extends CardProps {
 
 const ProposalCard = ({ proposal, ...cardProps }: Props) => {
   const [menuAnchorEl, setMenuAnchorEl] = useState<null | HTMLElement>(null);
-
   const [deleteProposal] = useDeleteProposalMutation();
   const { data } = useMeQuery();
 
@@ -78,13 +77,14 @@ const ProposalCard = ({ proposal, ...cardProps }: Props) => {
 
   const me = data && data.me;
   const isMe = me?.id === user.id;
-  const formattedDate = timeAgo(createdAt);
-
-  const groupPath = getGroupPath(group?.name || "");
   const isGroupPage = asPath.includes(NavigationPaths.Groups);
   const isProposalPage = asPath.includes(NavigationPaths.Proposals);
+  const disableCardFooter = !!group && !group.isJoinedByMe;
+
+  const groupPath = getGroupPath(group?.name || "");
   const proposalPath = `${NavigationPaths.Proposals}/${id}`;
   const userProfilePath = getUserProfilePath(user?.name);
+  const formattedDate = timeAgo(createdAt);
 
   const bodyStyles = {
     marginBottom:
@@ -221,7 +221,13 @@ const ProposalCard = ({ proposal, ...cardProps }: Props) => {
         </Link>
       </CardContent>
 
-      {me && <ProposalCardFooter proposal={proposal} currentUserId={me.id} />}
+      {me && (
+        <ProposalCardFooter
+          currentUserId={me.id}
+          disabled={disableCardFooter}
+          proposal={proposal}
+        />
+      )}
     </Card>
   );
 };

--- a/src/components/Proposals/ProposalCard.tsx
+++ b/src/components/Proposals/ProposalCard.tsx
@@ -79,7 +79,6 @@ const ProposalCard = ({ proposal, ...cardProps }: Props) => {
   const isMe = me?.id === user.id;
   const isGroupPage = asPath.includes(NavigationPaths.Groups);
   const isProposalPage = asPath.includes(NavigationPaths.Proposals);
-  const disableCardFooter = !!group && !group.isJoinedByMe;
 
   const groupPath = getGroupPath(group?.name || "");
   const proposalPath = `${NavigationPaths.Proposals}/${id}`;
@@ -221,13 +220,7 @@ const ProposalCard = ({ proposal, ...cardProps }: Props) => {
         </Link>
       </CardContent>
 
-      {me && (
-        <ProposalCardFooter
-          currentUserId={me.id}
-          disabled={disableCardFooter}
-          proposal={proposal}
-        />
-      )}
+      {me && <ProposalCardFooter currentUserId={me.id} proposal={proposal} />}
     </Card>
   );
 };

--- a/src/components/Proposals/ProposalCardFooter.tsx
+++ b/src/components/Proposals/ProposalCardFooter.tsx
@@ -25,9 +25,10 @@ const ROTATED_ICON_STYLES = {
 interface Props {
   currentUserId: number;
   proposal: ProposalCardFooterFragment;
+  disabled: boolean;
 }
 
-const ProposalCardFooter = ({ proposal, currentUserId }: Props) => {
+const ProposalCardFooter = ({ proposal, currentUserId, disabled }: Props) => {
   const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
   const { t } = useTranslation();
 
@@ -56,27 +57,41 @@ const ProposalCardFooter = ({ proposal, currentUserId }: Props) => {
 
   const handleVoteMenuClose = () => setMenuAnchorEl(null);
 
+  const handleCardActionsClick = () => {
+    if (!disabled) {
+      return;
+    }
+    toastVar({
+      status: "info",
+      title: t("proposals.prompts.joinGroupToVote"),
+    });
+  };
+
   return (
     <>
       {!!voteCount && <VoteBadges proposal={proposal} />}
 
       <Divider sx={{ margin: "0 16px" }} />
 
-      <CardActions sx={{ justifyContent: "space-around" }}>
+      <CardActions
+        sx={{ justifyContent: "space-around" }}
+        onClick={handleCardActionsClick}
+      >
         <CardFooterButton
           onClick={handleVoteButtonClick}
           sx={voteByCurrentUser ? { color: Blurple.Primary } : {}}
+          disabled={disabled}
         >
           <HowToVote sx={ICON_STYLES} />
           {voteButtonLabel}
         </CardFooterButton>
 
-        <CardFooterButton onClick={inDevToast}>
+        <CardFooterButton onClick={inDevToast} disabled={disabled}>
           <Comment sx={ROTATED_ICON_STYLES} />
           {t("actions.comment")}
         </CardFooterButton>
 
-        <CardFooterButton onClick={inDevToast}>
+        <CardFooterButton onClick={inDevToast} disabled={disabled}>
           <Reply sx={ROTATED_ICON_STYLES} />
           {t("actions.share")}
         </CardFooterButton>

--- a/src/components/Proposals/ProposalCardFooter.tsx
+++ b/src/components/Proposals/ProposalCardFooter.tsx
@@ -25,15 +25,16 @@ const ROTATED_ICON_STYLES = {
 interface Props {
   currentUserId: number;
   proposal: ProposalCardFooterFragment;
-  disabled: boolean;
 }
 
-const ProposalCardFooter = ({ proposal, currentUserId, disabled }: Props) => {
+const ProposalCardFooter = ({ proposal, currentUserId }: Props) => {
   const [menuAnchorEl, setMenuAnchorEl] = useState<HTMLElement | null>(null);
   const { t } = useTranslation();
 
-  const { stage, voteCount, votes } = proposal;
+  const { stage, voteCount, votes, group } = proposal;
+  const isDisabled = !!group && !group.isJoinedByMe;
   const isRatified = stage === ProposalStages.Ratified;
+
   const voteByCurrentUser = votes.find(
     (vote) => vote.user.id === currentUserId
   );
@@ -58,7 +59,7 @@ const ProposalCardFooter = ({ proposal, currentUserId, disabled }: Props) => {
   const handleVoteMenuClose = () => setMenuAnchorEl(null);
 
   const handleCardActionsClick = () => {
-    if (!disabled) {
+    if (!isDisabled) {
       return;
     }
     toastVar({
@@ -80,18 +81,18 @@ const ProposalCardFooter = ({ proposal, currentUserId, disabled }: Props) => {
         <CardFooterButton
           onClick={handleVoteButtonClick}
           sx={voteByCurrentUser ? { color: Blurple.Primary } : {}}
-          disabled={disabled}
+          disabled={isDisabled}
         >
           <HowToVote sx={ICON_STYLES} />
           {voteButtonLabel}
         </CardFooterButton>
 
-        <CardFooterButton onClick={inDevToast} disabled={disabled}>
+        <CardFooterButton onClick={inDevToast} disabled={isDisabled}>
           <Comment sx={ROTATED_ICON_STYLES} />
           {t("actions.comment")}
         </CardFooterButton>
 
-        <CardFooterButton onClick={inDevToast} disabled={disabled}>
+        <CardFooterButton onClick={inDevToast} disabled={isDisabled}>
           <Reply sx={ROTATED_ICON_STYLES} />
           {t("actions.share")}
         </CardFooterButton>

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -65,7 +65,8 @@
 
   "proposals": {
     "prompts": {
-      "createProposal": "Create a proposal..."
+      "createProposal": "Create a proposal...",
+      "joinGroupToVote": "You need to be a group member to interact with this proposal."
     },
     "actions": {
       "attachNewCoverPhoto": "Attach new cover photo",


### PR DESCRIPTION
Users are currently able to vote proposals posted to groups, even if they haven't joined the group that the proposal was posted to.

A `isJoinedByMe` field was added to the Group type that gets checked on the FE to prevent this.

Depends on: https://github.com/praxis-app/praxis-api/pull/117