### PR TITLE
fix: set error policy per query instead of globally

### DIFF
--- a/codegen.ts
+++ b/codegen.ts
@@ -23,9 +23,6 @@ const config: CodegenConfig = {
       ],
       config: {
         withHooks: true,
-        defaultBaseOptions: {
-          errorPolicy: "all",
-        },
       },
     },
     "./schema.graphql": {

--- a/src/apollo/gen.ts
+++ b/src/apollo/gen.ts
@@ -15,7 +15,7 @@ export type MakeOptional<T, K extends keyof T> = Omit<T, K> & {
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & {
   [SubKey in K]: Maybe<T[SubKey]>;
 };
-const defaultOptions = { errorPolicy: "all" } as const;
+const defaultOptions = {} as const;
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
   ID: string;

--- a/src/pages/groups/[name].tsx
+++ b/src/pages/groups/[name].tsx
@@ -16,6 +16,7 @@ const GroupPage: NextPage = () => {
   const name = String(query?.name || "");
   const { data, loading, error } = useGroupProfileQuery({
     variables: { name },
+    errorPolicy: "all",
     skip: !name,
   });
 

--- a/src/pages/groups/index.tsx
+++ b/src/pages/groups/index.tsx
@@ -30,6 +30,7 @@ const GroupsIndex: NextPage = () => {
   const inviteToken = useReactiveVar(inviteTokenVar);
 
   const { data, loading, error } = useGroupsQuery({
+    errorPolicy: "all",
     skip: !isLoggedIn,
   });
 


### PR DESCRIPTION
Resolve issues where mutations weren't throwing errors as expected.

GraphQL codegen makes it difficult to set a global error policy separately between queries and mutations. Setting error policy per query can serve as a temporary workaround for now.