### PR TITLE
Change group roles with proposals

### DIFF
--- a/src/constants/proposal.constants.ts
+++ b/src/constants/proposal.constants.ts
@@ -1,5 +1,4 @@
 export enum ProposalActionTypes {
-  AssignRole = "assign-role",
   ChangeCoverPhoto = "change-cover-photo",
   ChangeDescription = "change-description",
   ChangeName = "change-name",

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -74,7 +74,6 @@
       "vote": "Vote"
     },
     "actionTypes": {
-      "assignRole": "Assign Group Role",
       "changeDescription": "Change Group Description",
       "changeCoverPhoto": "Change Cover Photo",
       "changeName": "Change Group Name",

--- a/src/utils/proposal.utils.ts
+++ b/src/utils/proposal.utils.ts
@@ -23,10 +23,6 @@ export const getProposalActionTypeOptions = (
 
   // TODO: Uncomment after adding support for remaining action types
   // {
-  //   message: t("proposals.actionTypes.assignRole"),
-  //   value: ProposalActionTypes.AssignRole,
-  // },
-  // {
   //   message: t("proposals.actionTypes.changeRole"),
   //   value: ProposalActionTypes.ChangeRole,
   // },
@@ -63,8 +59,6 @@ export const getProposalActionLabel = (
       return t("proposals.actionTypes.createRole");
     case ProposalActionTypes.ChangeRole:
       return t("proposals.actionTypes.changeRole");
-    case ProposalActionTypes.AssignRole:
-      return t("proposals.actionTypes.assignRole");
     case ProposalActionTypes.Test:
       return t("proposals.actionTypes.test");
     default:


### PR DESCRIPTION
Enables group members to change group roles and permissions using proposals.

Depends on: https://github.com/praxis-app/praxis-api/pull/124