### PR TITLE
Add separate test case for image input in sign up

### DIFF
--- a/src/components/Auth/__tests__/SignUpForm.test.tsx
+++ b/src/components/Auth/__tests__/SignUpForm.test.tsx
@@ -125,7 +125,9 @@ describe("SignUpForm", () => {
       },
     });
 
-    const imagePreview = screen.getByTestId("attach-image-preview");
+    const imagePreview = screen.getByLabelText(
+      "images.labels.attachedImagePreview"
+    );
     expect(imagePreview).toBeInTheDocument();
 
     const removeButton = screen.getAllByLabelText("images.labels.removeImage");

--- a/src/components/Auth/__tests__/SignUpForm.test.tsx
+++ b/src/components/Auth/__tests__/SignUpForm.test.tsx
@@ -34,6 +34,16 @@ const toastVarMock = jest.fn();
 URL.createObjectURL = jest.fn();
 
 describe("SignUpForm", () => {
+  it("should show submit button as disabled when no field is entered", async () => {
+    render(
+      <MockedProvider>
+        <SignUpForm />
+      </MockedProvider>
+    );
+    const button = screen.getByRole("button", { name: "users.actions.signUp" });
+    expect(button).toBeDisabled();
+  });
+
   it("should call the signUp mutation when the submit button is clicked", async () => {
     const mockSignUpMutation = jest.fn();
     const mockOnCompleted = jest.fn();
@@ -133,15 +143,5 @@ describe("SignUpForm", () => {
     const removeButton = screen.getAllByLabelText("images.labels.removeImage");
     fireEvent.click(removeButton[0]);
     expect(imagePreview).not.toBeInTheDocument();
-  });
-
-  it("should show submit button as disabled when no field is entered", async () => {
-    render(
-      <MockedProvider>
-        <SignUpForm />
-      </MockedProvider>
-    );
-    const button = screen.getByRole("button", { name: "users.actions.signUp" });
-    expect(button).toBeDisabled();
   });
 });

--- a/src/components/Auth/__tests__/SignUpForm.test.tsx
+++ b/src/components/Auth/__tests__/SignUpForm.test.tsx
@@ -109,20 +109,28 @@ describe("SignUpForm", () => {
 
     const errorText = await screen.findByText("signUp.errors.missingEmail");
     expect(errorText).toBeInTheDocument();
+  });
+
+  it("should show image preview when user attaches image, and then hide it when user removes it", async () => {
+    render(
+      <MockedProvider>
+        <SignUpForm />
+      </MockedProvider>
+    );
 
     const inputElement = screen.getByLabelText("posts.labels.addImages");
-
     fireEvent.change(inputElement, {
       target: {
         files: [new File([], "test-image.png", { type: "image/png" })],
       },
     });
 
-    const imagePreview = screen.getByLabelText("images.labels.attachImages");
+    const imagePreview = screen.getByTestId("attach-image-preview");
     expect(imagePreview).toBeInTheDocument();
 
     const removeButton = screen.getAllByLabelText("images.labels.removeImage");
     fireEvent.click(removeButton[0]);
+    expect(imagePreview).not.toBeInTheDocument();
   });
 
   it("should show submit button as disabled when no field is entered", async () => {

--- a/src/components/Auth/__tests__/SignUpForm.test.tsx
+++ b/src/components/Auth/__tests__/SignUpForm.test.tsx
@@ -118,7 +118,7 @@ describe("SignUpForm", () => {
       </MockedProvider>
     );
 
-    const inputElement = screen.getByLabelText("posts.labels.addImages");
+    const inputElement = screen.getByLabelText("images.labels.attachImages");
     fireEvent.change(inputElement, {
       target: {
         files: [new File([], "test-image.png", { type: "image/png" })],

--- a/src/components/Images/AttachedImagePreview.tsx
+++ b/src/components/Images/AttachedImagePreview.tsx
@@ -56,6 +56,7 @@ const AttachedImagePreview = ({
         flexWrap: "wrap",
         ...sx,
       }}
+      data-testid="attach-image-preview"
     >
       {savedImages &&
         savedImages.map(({ id, filename }) => (

--- a/src/components/Images/AttachedImagePreview.tsx
+++ b/src/components/Images/AttachedImagePreview.tsx
@@ -40,6 +40,8 @@ const AttachedImagePreview = ({
   selectedImages,
   sx,
 }: Props) => {
+  const { t } = useTranslation();
+
   const containerStyles: SxProps = {
     marginBottom: 2.5,
     marginRight: 3.5,
@@ -50,13 +52,13 @@ const AttachedImagePreview = ({
 
   return (
     <Box
+      aria-label={t("images.labels.attachedImagePreview")}
       sx={{
         marginTop: 2,
         display: "flex",
         flexWrap: "wrap",
         ...sx,
       }}
-      data-testid="attach-image-preview"
     >
       {savedImages &&
         savedImages.map(({ id, filename }) => (

--- a/src/components/Images/ImageInput.tsx
+++ b/src/components/Images/ImageInput.tsx
@@ -50,11 +50,7 @@ const ImageInput = ({
       return children;
     }
     return (
-      <IconButton
-        aria-label={t("images.labels.attachImages")}
-        disableRipple
-        edge="start"
-      >
+      <IconButton disableRipple edge="start">
         <Image sx={{ fontSize: 40 }} />
       </IconButton>
     );
@@ -64,7 +60,7 @@ const ImageInput = ({
     <Box marginTop={0.35} {...boxProps}>
       <input
         accept="image/*"
-        aria-label={t("posts.labels.addImages")}
+        aria-label={t("images.labels.attachImages")}
         key={refreshKey}
         multiple={multiple}
         name={name}

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -302,6 +302,7 @@
 
   "images": {
     "labels": {
+      "attachedImagePreview": "Attached image preview",
       "attachedImages": "Attached images",
       "attachImages": "Attach images",
       "coverPhoto": "Cover photo",


### PR DESCRIPTION
Adds a separate test case for testing both image input and image preview in the sign up form.